### PR TITLE
Important fixes

### DIFF
--- a/lib/compat.h
+++ b/lib/compat.h
@@ -71,7 +71,7 @@ typedef struct _GUID {
 } GUID;
 
 /* HV Socket definitions */
-#define AF_HYPERV 42
+#define AF_HYPERV 43
 #define HV_PROTOCOL_RAW 1
 
 typedef struct _SOCKADDR_HV

--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -115,11 +115,11 @@ CAMLprim value stub_hvsock_accept(value sock){
 
   caml_release_runtime_system();
   csock = accept(lsock, (struct sockaddr *)&sac, &socklen);
+  caml_acquire_runtime_system();
   if (csock == INVALID_SOCKET) {
     win32_maperr(WSAGetLastError());
     uerror("accept", Nothing);
   }
-  caml_acquire_runtime_system();
 
   result = caml_alloc_tuple(3);
   Store_field(result, 0, win_alloc_socket(csock));


### PR DESCRIPTION
The kernel socket family ID is not stable since the patches are not yet upstream. Hardcode the new current `AF_HYPERV` number (43)

Avoid raising `Unix_error` without first acquiring the runtime lock.