### PR TITLE
Flow_lwt_hvsock_shutdown: in shutdown_{read,write} don't fail the thread

### DIFF
--- a/lwt/flow_lwt_hvsock_shutdown.ml
+++ b/lwt/flow_lwt_hvsock_shutdown.ml
@@ -141,7 +141,9 @@ let shutdown_write flow =
       (fun () ->
         really_write flow.fd Message.(marshal ShutdownWrite) 0 Message.sizeof
         >>= function
-        | `Eof -> Lwt.fail End_of_file
+        | `Eof ->
+          Log.err (fun f -> f "Lwt_hvsock.shutdown_write: got Eof");
+          Lwt.return ()
         | `Ok () -> Lwt.return ()
       )
   end
@@ -155,7 +157,9 @@ let shutdown_read flow =
       (fun () ->
         really_write flow.fd Message.(marshal ShutdownRead) 0 Message.sizeof
         >>= function
-        | `Eof -> Lwt.fail End_of_file
+        | `Eof ->
+          Log.err (fun f -> f "Lwt_hvsock.shutdown_write: got Eof");
+          Lwt.return ()
         | `Ok () -> Lwt.return ()
       )
   end


### PR DESCRIPTION
On Eof, return () as the connection is effectively shutdown now.

Signed-off-by: David Scott <dave.scott@docker.com>