### PR TITLE
Functorise to make Uwt compatible

### DIFF
--- a/lwt/flow_lwt_hvsock.ml
+++ b/lwt/flow_lwt_hvsock.ml
@@ -44,7 +44,7 @@ type flow = {
 }
 
 let connect fd =
-  let read_buffer_size = 1024 in
+  let read_buffer_size = 4 * 1024 in
   let closed = false in
   { fd; read_buffer_size; closed }
 

--- a/lwt/flow_lwt_hvsock.mli
+++ b/lwt/flow_lwt_hvsock.mli
@@ -16,8 +16,12 @@
  *
  *)
 
-include V1_LWT.FLOW
+module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN): sig
+  include V1_LWT.FLOW
 
-val connect: Lwt_hvsock.t -> flow
+  module Hvsock: Lwt_hvsock.HVSOCK
 
-val read_into: flow -> Cstruct.t -> [ `Eof | `Error of error | `Ok of unit ] Lwt.t
+  val connect: Hvsock.t -> flow
+
+  val read_into: flow -> Cstruct.t -> [ `Eof | `Error of error | `Ok of unit ] Lwt.t
+end

--- a/lwt/flow_lwt_hvsock_shutdown.mli
+++ b/lwt/flow_lwt_hvsock_shutdown.mli
@@ -21,8 +21,13 @@
     https://github.com/rneugeba/virtsock/tree/master/go/hvsock
 *)
 
-include Mirage_flow_s.SHUTDOWNABLE
+module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN): sig
 
-val read_into: flow -> Cstruct.t -> [ `Eof | `Error of error | `Ok of unit ] Lwt.t
+  include Mirage_flow_s.SHUTDOWNABLE
 
-val connect: Lwt_hvsock.t -> flow
+  module Hvsock: Lwt_hvsock.HVSOCK
+
+  val read_into: flow -> Cstruct.t -> [ `Eof | `Error of error | `Ok of unit ] Lwt.t
+
+  val connect: Hvsock.t -> flow
+end

--- a/lwt/lwt_hvsock.mli
+++ b/lwt/lwt_hvsock.mli
@@ -17,31 +17,42 @@
 
 open Hvsock
 
-type t
-(** A Hyper-V socket *)
+module type MAIN = sig
+  val run_in_main: (unit -> 'a Lwt.t) -> 'a
+  (** Run the given closure in the main thread *)
+end
 
-val create: unit -> t
-(** [create ()] creates an unbound AF_HVSOCK socket *)
+module type HVSOCK = sig
+  type t
+  (** A Hyper-V socket *)
 
-val bind: t -> sockaddr -> unit
-(** [bind t sockaddr] binds [socket] to [sockaddr] *)
+  val create: unit -> t
+  (** [create ()] creates an unbound AF_HVSOCK socket *)
 
-val listen: t -> int -> unit
-(** [listen t queue] *)
+  val bind: t -> sockaddr -> unit
+  (** [bind t sockaddr] binds [socket] to [sockaddr] *)
 
-val accept: t -> (t * sockaddr) Lwt.t
-(** [accept t] accepts a single connection *)
+  val listen: t -> int -> unit
+  (** [listen t queue] *)
 
-val connect: t -> sockaddr -> unit Lwt.t
-(** [connect t sockaddr] connects to a remote partition *)
+  val accept: t -> (t * sockaddr) Lwt.t
+  (** [accept t] accepts a single connection *)
 
-val read: t -> Bytes.t -> int -> int -> int Lwt.t
-(** [read t buf offset len] reads up to [len] bytes from [t] into [buf]
-    starting at offset [offset] *)
+  val connect: t -> sockaddr -> unit Lwt.t
+  (** [connect t sockaddr] connects to a remote partition *)
 
-val write: t -> Bytes.t -> int -> int -> int Lwt.t
-(** [write t buf offset len] writes up to [len] bytes from [t] into [buf]
-    starting at offset [offset] *)
+  val read: t -> Bytes.t -> int -> int -> int Lwt.t
+  (** [read t buf offset len] reads up to [len] bytes from [t] into [buf]
+      starting at offset [offset] *)
 
-val close: t -> unit Lwt.t
-(** [close t] closes a socket *)
+  val write: t -> Bytes.t -> int -> int -> int Lwt.t
+  (** [write t buf offset len] writes up to [len] bytes from [t] into [buf]
+      starting at offset [offset] *)
+
+  val close: t -> unit Lwt.t
+  (** [close t] closes a socket *)
+end
+
+module Make(Time: V1_LWT.TIME)(Main: MAIN): HVSOCK
+(** Create an HVSOCK implementation given the ability to sleep and the ability
+    to run code in the main Lwt thread *)


### PR DESCRIPTION
A Uwt application cannot use

- Lwt_unix.sleep
- Lwt_preemptive.run_in_main

This allows a Uwt implementation to provide alternatives (`Uwt.Timer.sleep` and `Uwt.preemptive.run_in_main`)