### PR TITLE
hvsock: handle errors in send,recv where WSAGetLastError() == 0

### DIFF
--- a/lib/hvsock_stubs.c
+++ b/lib/hvsock_stubs.c
@@ -189,7 +189,7 @@ stub_hvsock_ba_recv(value fd, value val_buf, value val_ofs, value val_len)
   if (ret == SOCKET_ERROR) err = WSAGetLastError();
   caml_acquire_runtime_system();
 
-  if (err) {
+  if (ret == SOCKET_ERROR) {
     win32_maperr(err);
     uerror("read", Nothing);
   }
@@ -212,7 +212,7 @@ stub_hvsock_ba_send(value fd, value val_buf, value val_ofs, value val_len)
   if (ret == SOCKET_ERROR) err = WSAGetLastError();
   caml_acquire_runtime_system();
 
-  if (err) {
+  if (ret == SOCKET_ERROR) {
     win32_maperr(err);
     uerror("read", Nothing);
   }


### PR DESCRIPTION
Although WSAGetLastError() should not be 0 when a socket error has
happened, with Hyper-V sockets I have seen this happen.

This patch makes send and recv more robust by failing with a
Unix_error if `ret == SOCKET_ERROR` nomatter what the result of
`WSAGetLastError`.

Signed-off-by: David Scott <dave@recoil.org>