### PR TITLE
Really disable debug logging in the Flow_lwt_hvsock_shutdown code

### DIFF
--- a/lwt/flow_lwt_hvsock_shutdown.ml
+++ b/lwt/flow_lwt_hvsock_shutdown.ml
@@ -17,7 +17,7 @@
 
 let src =
   let src = Logs.Src.create "flow_lwt_hvsock_shutdown" ~doc:"AF_HYPERV framed messages" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>